### PR TITLE
Fix error for null list. use empty instance

### DIFF
--- a/HolyPlugy/StashCollection.cs
+++ b/HolyPlugy/StashCollection.cs
@@ -14,7 +14,11 @@ namespace HolyPlugy
         }
         public void setStashes(List<Stash> stashes)
         {
-            this.stashes = stashes;
+            if (stashes == null) {
+                this.stashes = new List<Stash>();
+            } else {
+                this.stashes = stashes;
+            }
         }
         public String getFileName()
         {


### PR DESCRIPTION
I was failing on Line 775 in `HolyPlugy\MainWindow.xaml.cs`

```cs
if (isUniqueInStash(uniqueConstant, library.getStashes(),checkEth))
```

`HolyPlugy.StashCollection.getStashes(...) returned null.`

the logic added to setStashes() addresses a case of a null list